### PR TITLE
add MySky and UserProfile DAC

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "@fontsource/source-sans-pro": "^4.2.2",
     "@headlessui/react": "^1.0.0",
     "@heroicons/react": "^1.0.1",
+    "@skynethub/userprofile-library": "^0.1.5-beta",
     "@testing-library/jest-dom": "^5.11.4",
     "@testing-library/react": "^11.1.0",
     "@testing-library/user-event": "^12.1.10",
@@ -22,7 +23,7 @@
     "react-router-dom": "^5.2.0",
     "react-scripts": "4.0.3",
     "react-use": "^17.2.3",
-    "skynet-js": "^3.0.2",
+    "skynet-js": "^4.0.2-beta",
     "swr": "^0.5.5",
     "web-vitals": "^1.0.1"
   },

--- a/src/App.js
+++ b/src/App.js
@@ -2,18 +2,21 @@ import React from "react";
 import { HashRouter as Router, Switch, Route } from "react-router-dom";
 import LandingPage from "./pages/LandingPage";
 import LeaderboardPage from "./pages/LeaderboardPage";
+import { SkynetProvider } from "./state/SkynetContext";
 
 export default function App() {
   return (
     <Router>
-      <Switch>
-        <Route exact path="/">
-          <LandingPage />
-        </Route>
-        <Route path="/leaderboard">
-          <LeaderboardPage />
-        </Route>
-      </Switch>
+      <SkynetProvider>
+        <Switch>
+          <Route exact path="/">
+            <LandingPage />
+          </Route>
+          <Route path="/leaderboard">
+            <LeaderboardPage />
+          </Route>
+        </Switch>
+      </SkynetProvider>
     </Router>
   );
 }

--- a/src/components/MySkyButton.js
+++ b/src/components/MySkyButton.js
@@ -1,0 +1,110 @@
+import { useEffect, useContext, useState } from "react";
+// import { Button, Icon, Loader } from 'semantic-ui-react';
+// import { useStoreState, useStoreActions, useStore } from 'easy-peasy';
+import { SkynetContext } from "../state/SkynetContext";
+import { UserCircleIcon } from "@heroicons/react/outline";
+
+const MySkyButton = () => {
+  const { mySky, userProfile } = useContext(SkynetContext);
+  const [loggedIn, setLoggedIn] = useState(false); //This will get moved to global state.
+  const [loading, setLoading] = useState(true); //This will get moved to global state.
+  const [profile, setProfile] = useState();
+  const [avatar, setAvatar] = useState();
+  const [userID, setUserID] = useState();
+  // const { fetchUserID, logout } = useStoreActions((state) => state.mySky);
+  // const { loggedIn } = useStoreState((state) => state.mySky);
+  // const { store } = useStore();
+
+  useEffect(() => {
+    // if we have MySky loaded
+    setLoading(true);
+    setAvatar(null);
+    setProfile(null);
+    if (mySky) {
+      mySky.checkLogin().then((result) => {
+        if (result) {
+          handleLoginSuccess();
+        }
+        setLoading(false);
+      });
+    }
+  }, [mySky]);
+
+  useEffect(() => {
+    if (profile) {
+      const skylink = profile.avatar;
+      mySky.connector.client.getSkylinkUrl(skylink).then((avatarUrl) => {
+        setAvatar(avatarUrl + "/300");
+      });
+    }
+  }, [profile]);
+
+  const onLogin = () => {
+    setLoading(true);
+    setAvatar(null);
+    setProfile(null);
+    mySky.requestLoginAccess().then((result) => {
+      if (result) {
+        handleLoginSuccess();
+      }
+      setLoading(false);
+    });
+  };
+
+  const onLogout = () => {
+    mySky.logout();
+    setLoggedIn(false);
+  };
+
+  const handleLoginSuccess = async () => {
+    setLoggedIn(true);
+    mySky.userID().then((userID) => {
+      setUserID(userID);
+      userProfile.getProfile(userID).then((result) => {
+        console.log("profile", result);
+        setProfile(result);
+      });
+    });
+  };
+
+  return (
+    <>
+      {loading && (
+        <button className="group flex items-center px-2 py-2 text-sm font-medium rounded-md nav-link">[Spinner]</button>
+      )}
+      {!loading && !loggedIn && (
+        <button className="group flex items-center px-2 py-2 text-sm font-medium rounded-md nav-link" onClick={onLogin}>
+          <UserCircleIcon className="mr-3 h-6 w-6" aria-hidden="true" />
+          MySky Login
+        </button>
+      )}
+      {!loading && loggedIn && (
+        <>
+          <button
+            className="group flex items-center px-2 py-2 text-sm font-medium rounded-md nav-link"
+            onClick={onLogout}
+          >
+            <UserCircleIcon className="mr-3 h-6 w-6" aria-hidden="true" />
+            {profile ? "Logout: " + profile.username : "MySky Logout"}
+          </button>
+          <img src={avatar} />
+        </>
+      )}
+    </>
+  );
+};
+
+export default MySkyButton;
+
+// // Example profile object converted from SkyID profile:
+// {
+//   "version": 1,
+//   "username": "dghelm",
+//   "aboutMe": "Developer Evangelist for Skynet Labs.",
+//   "location": "Oklahoma City, OK, USA",
+//   "topics": [],
+//   "avatar": "jADT7g5u7GRJ7YfSoFGeWozCkJF2eJrJSeq9mZeu4LCiXg"
+// }
+
+// Avatar is a folder with various size images named: ["50","150","300","600","1920"]
+// If original image size is smaller than name's dimensions, the size actually the original upload size, despite the file's name.

--- a/src/pages/LeaderboardPage.js
+++ b/src/pages/LeaderboardPage.js
@@ -6,6 +6,7 @@ import { ReactComponent as Logo } from "../svg/LogoWhiteText.svg";
 import SkappPage from "./Leaderboard/SkappPage";
 import ContentPage from "./Leaderboard/ContentPage";
 import UserPage from "./Leaderboard/UserPage";
+import MySkyButton from "../components/MySkyButton";
 
 const navigation = [
   { name: "Skapp ranking", to: "/leaderboard", icon: CubeTransparentIcon },
@@ -116,6 +117,7 @@ export default function LeaderboardPage({ ...props }) {
                     {item.name}
                   </NavLink>
                 ))}
+                <MySkyButton />
               </nav>
             </div>
           </div>

--- a/src/state/SkynetContext.js
+++ b/src/state/SkynetContext.js
@@ -1,0 +1,71 @@
+import { createContext, useState, useEffect } from "react";
+import { SkynetClient } from "skynet-js";
+
+// To import DAC, uncomment here, and 2 spots below.
+// import { ContentRecordDAC } from '@skynetlabs/content-record-library';
+import { UserProfileDAC } from "@skynethub/userprofile-library";
+
+const SkynetContext = createContext(undefined);
+
+// We'll define a portal to allow for developing on localhost.
+// When hosted on a skynet portal, SkynetClient doesn't need any arguments.
+const portal = window.location.hostname === "localhost" ? "https://siasky.net" : undefined;
+
+// Initiate the SkynetClient
+const client = new SkynetClient(portal);
+
+// For now, we won't use any DACs -- uncomment to create
+// const contentRecord = new ContentRecordDAC();
+const contentRecord = null;
+const userProfile = new UserProfileDAC();
+
+const dataDomain = window.location.hostname === "localhost" ? "localhost" : "skynet-hackathon.hns";
+
+const SkynetProvider = ({ children }) => {
+  const [skynetState, setSkynetState] = useState({
+    client,
+    mySky: null,
+    // contentRecord,
+    userProfile,
+    dataDomain,
+  });
+
+  useEffect(() => {
+    // define async setup function
+    async function initMySky() {
+      try {
+        // load invisible iframe and define app's data domain
+        // needed for permissions write
+        const mySky = await client.loadMySky(dataDomain, {
+          debug: true,
+          // dev: true,
+        });
+
+        // load necessary DACs and permissions
+        // Uncomment line below to load DACs
+        // await mySky.loadDacs(contentRecord);
+        // await mySky.loadDacs(userProfile);
+
+        // replace mySky in state object
+        setSkynetState({ ...skynetState, mySky, userProfile });
+      } catch (e) {
+        console.error(e);
+      }
+    }
+
+    // call async setup function
+    if (!skynetState.mySky) {
+      initMySky();
+    }
+
+    return () => {
+      if (skynetState.mySky) {
+        skynetState.mySky.destroy();
+      }
+    };
+  }, [skynetState]);
+
+  return <SkynetContext.Provider value={skynetState}>{children}</SkynetContext.Provider>;
+};
+
+export { SkynetContext, SkynetProvider };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1970,6 +1970,15 @@
   dependencies:
     "@sinonjs/commons" "^1.7.0"
 
+"@skynethub/userprofile-library@^0.1.5-beta":
+  version "0.1.5-beta"
+  resolved "https://registry.yarnpkg.com/@skynethub/userprofile-library/-/userprofile-library-0.1.5-beta.tgz#b80155856391d69dd0189a14d3a376ca58754d05"
+  integrity sha512-IJwQtCExamYs3Z39UcQsCMnBVTxr7+kKP/zyOgv6UEgdcdDheTjbFbSjjOmYfsyg0VrCmplG7pNBL0HkdbRvkQ==
+  dependencies:
+    post-me "^0.4.5"
+    skynet-js "^4.0.1-beta"
+    skynet-mysky-utils "^0.1.0"
+
 "@surma/rollup-plugin-off-main-thread@^1.1.1":
   version "1.4.2"
   resolved "https://registry.yarnpkg.com/@surma/rollup-plugin-off-main-thread/-/rollup-plugin-off-main-thread-1.4.2.tgz#e6786b6af5799f82f7ab3a82e53f6182d2b91a58"
@@ -9010,6 +9019,11 @@ posix-character-classes@^0.1.0:
   resolved "https://registry.yarnpkg.com/posix-character-classes/-/posix-character-classes-0.1.1.tgz#01eac0fe3b5af71a2a6c02feabb8c1fef7e00eab"
   integrity sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=
 
+post-me@^0.4.5:
+  version "0.4.5"
+  resolved "https://registry.yarnpkg.com/post-me/-/post-me-0.4.5.tgz#6171b721c7b86230c51cfbe48ddea047ef8831ce"
+  integrity sha512-XgPdktF/2M5jglgVDULr9NUb/QNv3bY3g6RG22iTb5MIMtB07/5FJB5fbVmu5Eaopowc6uZx7K3e7x1shPwnXw==
+
 postcss-attribute-case-insensitive@^4.0.1:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/postcss-attribute-case-insensitive/-/postcss-attribute-case-insensitive-4.0.2.tgz#d93e46b504589e94ac7277b0463226c68041a880"
@@ -11024,10 +11038,10 @@ sjcl@^1.0.8:
   resolved "https://registry.yarnpkg.com/sjcl/-/sjcl-1.0.8.tgz#f2ec8d7dc1f0f21b069b8914a41a8f236b0e252a"
   integrity sha512-LzIjEQ0S0DpIgnxMEayM1rq9aGwGRG4OnZhCdjx7glTaJtf4zRfpg87ImfjSJjoW9vKpagd82McDOwbRT5kQKQ==
 
-skynet-js@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/skynet-js/-/skynet-js-3.0.2.tgz#d08a33066ee85b86e4ffc7c31591239a88da6fbe"
-  integrity sha512-rbmpOGbDwg2FcsZ7HkmGhVaUwWO6kaysRFKTBC3yGiV+b6fbnpPPNCskvh8kWwbTsj+koWkSRUFYqG7cc+eTuA==
+skynet-js@^4.0.1-beta:
+  version "4.0.1-beta"
+  resolved "https://registry.yarnpkg.com/skynet-js/-/skynet-js-4.0.1-beta.tgz#cafe16c4534c6da260cc7205cdda103d367c5cb0"
+  integrity sha512-OtuMVeM8b1RySHi4TByhtVv1Oxd7sIcC4fRZaQnVL3qqQba99DgR8nvg8uXbblD1nxiB0dUR/p0Yrck8QOGW/A==
   dependencies:
     "@babel/runtime" "^7.11.2"
     axios "^0.21.0"
@@ -11037,11 +11051,41 @@ skynet-js@^3.0.2:
     buffer "^6.0.1"
     mime "^2.5.2"
     path-browserify "^1.0.1"
+    post-me "^0.4.5"
     randombytes "^2.1.0"
     sjcl "^1.0.8"
+    skynet-mysky-utils "^0.1.2"
     tweetnacl "^1.0.3"
     url-join "^4.0.1"
-    url-parse "^1.4.7"
+    url-parse "1.4.7"
+
+skynet-js@^4.0.2-beta:
+  version "4.0.2-beta"
+  resolved "https://registry.yarnpkg.com/skynet-js/-/skynet-js-4.0.2-beta.tgz#f9f7bd85b6d16a183536d379a757beffeea2fb64"
+  integrity sha512-km4mxygq3BPBfaKT6q62gTazd1zLbxaN7jL/bEBJZJphm3eB0P5/hMR6heDO7Gou8bbYpYRNqX0Fn1pNBAlMfA==
+  dependencies:
+    "@babel/runtime" "^7.11.2"
+    axios "^0.21.0"
+    base32-encode "^1.1.1"
+    base64-js "^1.3.1"
+    blakejs "^1.1.0"
+    buffer "^6.0.1"
+    mime "^2.5.2"
+    path-browserify "^1.0.1"
+    post-me "^0.4.5"
+    randombytes "^2.1.0"
+    sjcl "^1.0.8"
+    skynet-mysky-utils "^0.1.2"
+    tweetnacl "^1.0.3"
+    url-join "^4.0.1"
+    url-parse "1.4.7"
+
+skynet-mysky-utils@^0.1.0, skynet-mysky-utils@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/skynet-mysky-utils/-/skynet-mysky-utils-0.1.2.tgz#1ca5e9cf69a71ac67dd805c90371fd71f622adc1"
+  integrity sha512-ehPGwIIMldrG6S4ynkvElcqMeSrT85ignto1z/Nx3yFcHiiNDRLq5y6ZGXdSSNw2XfVSi8e66wjbL0qlNNCZog==
+  dependencies:
+    post-me "^0.4.5"
 
 slash@^3.0.0:
   version "3.0.0"
@@ -12154,7 +12198,15 @@ url-loader@4.1.1:
     mime-types "^2.1.27"
     schema-utils "^3.0.0"
 
-url-parse@^1.4.3, url-parse@^1.4.7, url-parse@^1.5.1:
+url-parse@1.4.7:
+  version "1.4.7"
+  resolved "https://registry.yarnpkg.com/url-parse/-/url-parse-1.4.7.tgz#a8a83535e8c00a316e403a5db4ac1b9b853ae278"
+  integrity sha512-d3uaVyzDB9tQoSXFvuSUNFibTd9zxd2bkVrDRvF5TmvWWQwqE4lgYJ5m+x1DbecWkw+LK4RNl2CU1hHuOKPVlg==
+  dependencies:
+    querystringify "^2.1.1"
+    requires-port "^1.0.0"
+
+url-parse@^1.4.3, url-parse@^1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/url-parse/-/url-parse-1.5.1.tgz#d5fa9890af8a5e1f274a2c98376510f6425f6e3b"
   integrity sha512-HOfCOUJt7iSYzEx/UqgtwKRMC6EU91NFhsCHMv9oM03VJcVo2Qrp8T8kI9D7amFf1cu+/3CEhgb3rF9zL7k85Q==


### PR DESCRIPTION
Rough code, tried to minimally touch your code, but PR adds React Context for storing client, mysky and dacs, wraps App in a Provider, and then accesses this state in MySkyButton.js, which I slipped into the Desktop nav bar.

MySkyButton.js handles login and logout, and also shows loading a user profile. It does not load the full UserProfile DAC -- it just uses the library portion for loading Profile entries by userID.